### PR TITLE
Feat/block open gl

### DIFF
--- a/src/ui/opengl_canvas.py
+++ b/src/ui/opengl_canvas.py
@@ -155,7 +155,7 @@ class OpenGLCanvas(glcanvas.GLCanvas, IUIBehavior):
                 self.Bind(wx.EVT_PAINT, self.on_paint)
                 self.Refresh()
         else:
-            wx.StaticText(self, label="OpenGL is unavailable.")
+            wx.StaticText(self, label="OpenGL is unavailable. Version 3.3 or higher is required.")
 
     def update(self, dt: float):
         """Called every loop by the GUIEventLoop

--- a/src/ui/opengl_canvas.py
+++ b/src/ui/opengl_canvas.py
@@ -29,6 +29,7 @@ class OpenGLCanvas(glcanvas.GLCanvas, IUIBehavior):
     """This is the canvas for OpenGL to render objects to.
     """
     canvas_size = (400, 300)
+    render_text = None
 
     def __init__(self, parent):
         """Default constructor for OpenGLCanvas class.
@@ -155,7 +156,9 @@ class OpenGLCanvas(glcanvas.GLCanvas, IUIBehavior):
                 self.Bind(wx.EVT_PAINT, self.on_paint)
                 self.Refresh()
         else:
-            wx.StaticText(self, label="OpenGL is unavailable. Version 3.3 or higher is required.")
+            self.render_text = wx.StaticText(self, label="OpenGL is unavailable. Version 3.3 or higher is required.")
+            self.render_text.SetForegroundColour("white")
+
 
     def update(self, dt: float):
         """Called every loop by the GUIEventLoop

--- a/src/ui/opengl_canvas.py
+++ b/src/ui/opengl_canvas.py
@@ -107,6 +107,8 @@ class OpenGLCanvas(glcanvas.GLCanvas, IUIBehavior):
         print("OpenGL Minor: " + str(RenderingEngine.gl_version_major_minor()[1]))
         print("GLSL Major: " + str(RenderingEngine.glsl_version_major_minor()[0]))
         print("GLSL Minor: " + str(RenderingEngine.glsl_version_major_minor()[1]))
+        UIStyle.render_info = RenderingEngine.gl_version_major_minor()[0]
+        print(UIStyle)
 
     def draw(self):
         """Draw the previous OpenGL buffer with all the 3D data.
@@ -120,8 +122,9 @@ class OpenGLCanvas(glcanvas.GLCanvas, IUIBehavior):
             glPolygonMode(GL_FRONT_AND_BACK, GL_FILL)
 
         self.Refresh()
-        self.scene.draw()
-        self.SwapBuffers()
+        if self.scene is not None:
+            self.scene.draw()
+            self.SwapBuffers()
 
     def on_state_changed(self, new_state: ApplicationState):
         """A state change was passed to the OpenGLCanvas.
@@ -137,7 +140,7 @@ class OpenGLCanvas(glcanvas.GLCanvas, IUIBehavior):
         :param event: The recorded UserEvent.
         :return: None
         """
-        if event is not None:
+        if event is not None and UIStyle.render_info >= 3:
             if event.get_event_type() == UserEventType.INPUT_MODEL_READY:
                 self.scene.replace_input_model_mesh(ModelShipper.input_model.mesh)
                 self.scene.replace_output_model_mesh(None)

--- a/src/ui/opengl_canvas.py
+++ b/src/ui/opengl_canvas.py
@@ -156,9 +156,10 @@ class OpenGLCanvas(glcanvas.GLCanvas, IUIBehavior):
                 self.Bind(wx.EVT_PAINT, self.on_paint)
                 self.Refresh()
         else:
-            self.render_text = wx.StaticText(self, label="OpenGL is unavailable. Version 3.3 or higher is required.")
-            self.render_text.SetForegroundColour("white")
-
+            self.render_text = wx.StaticText(self, label="OpenGL is unavailable. Version 3.3 or higher is required.",
+                                             style=wx.STAY_ON_TOP)
+            self.render_text.SetForegroundColour(UIStyle.render_text_color)
+            self.render_text.SetBackgroundColour("black")
 
     def update(self, dt: float):
         """Called every loop by the GUIEventLoop

--- a/src/ui/opengl_canvas.py
+++ b/src/ui/opengl_canvas.py
@@ -108,7 +108,7 @@ class OpenGLCanvas(glcanvas.GLCanvas, IUIBehavior):
         print("GLSL Major: " + str(RenderingEngine.glsl_version_major_minor()[0]))
         print("GLSL Minor: " + str(RenderingEngine.glsl_version_major_minor()[1]))
         UIStyle.render_info = RenderingEngine.gl_version_major_minor()[0]
-        print(UIStyle)
+        print(UIStyle.render_info)
 
     def draw(self):
         """Draw the previous OpenGL buffer with all the 3D data.
@@ -154,6 +154,8 @@ class OpenGLCanvas(glcanvas.GLCanvas, IUIBehavior):
             if event.get_event_type() == UserEventType.RENDERING_CANVAS_ENABLE:
                 self.Bind(wx.EVT_PAINT, self.on_paint)
                 self.Refresh()
+        else:
+            wx.StaticText(self, label="OpenGL is unavailable.")
 
     def update(self, dt: float):
         """Called every loop by the GUIEventLoop

--- a/src/ui/ui_style.py
+++ b/src/ui/ui_style.py
@@ -64,6 +64,7 @@ class UIStyle:
     log_font_size = 9
 
     # OpenGL
+    render_text_color = "white"
     opengl_panel_border = wx.BORDER_SUNKEN
     opengl_canvas_background_color = [0, 0, 0, 255]
     opengl_label_color = "#666666"
@@ -122,3 +123,4 @@ class UIStyle:
         UIStyle.log_font_size = 10
 
         # OpenGL Panel
+        UIStyle.render_text_color = "white"

--- a/src/ui/ui_style.py
+++ b/src/ui/ui_style.py
@@ -15,6 +15,7 @@ class UIStyle:
     border and text color.
     The color scheme in this class is the default color (for debug).
     """
+    render_info = 9
     # Utility
     button_background = ""
     button_text = ""


### PR DESCRIPTION
-Now it will check version. Only accept version 3. or above.  …
-The notification on OpenGL canvas is now asking user to have OpenGL 3.3 or above.
-If user has OpenGL below 3, display notification instead (so no error in the console)
-Working really well on Mac for this guard.
--------------------------------------------
Issue:
-Doesn't work that well in Windows (still display, but not constantly same as Mac). This is a known issue.
-The test should be from 3.3 and above, not 3.0