### PR TITLE
Handled Numpy RuntimeWarning to take care of bad STL files

### DIFF
--- a/src/model_conversion/model_shipper.py
+++ b/src/model_conversion/model_shipper.py
@@ -13,6 +13,8 @@ import logging
 from stl import Mesh
 from src.settings_manager import SettingsManager
 import json
+import numpy
+import warnings
 
 
 class ModelShipper:
@@ -32,9 +34,12 @@ class ModelShipper:
         :param file_path: The path to the stl file.
         :return: The BaseStl model (numpy-stl) loaded from the file_path or None.
         """
+        # turn numpy RuntimeWarning to actual error to avoid invalid STL files
+        numpy.seterr(all='warn')
+        warnings.filterwarnings('error')
         try:
             return Mesh.from_file(file_path)
-        except Exception as err:
+        except (Exception, RuntimeWarning) as err:
             logging.error(f"Failed to open the STL file : {err}")
             return False
 


### PR DESCRIPTION
I was testing STL files that Gene gave us and found that Cover.stl (png file) gives lots of numpy Runtime warnings while converting into Mesh. None of the valid STL file that we have loaded so far gave such errors. So I turned that numpy warning into an error and handled to avoid reading such STL files in the first case. Now the Cover.stl file gives Invalid file message to the user. 